### PR TITLE
Update resin docker build and fix invalid context errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,61 +16,28 @@ buildSteps: &buildSteps
         - ./node-*
 
 jobs:
-  "node-6":
+  'node-6':
     docker:
       - image: circleci/node:6
     working_directory: ~/node-6
     steps: *buildSteps
 
-  "node-8":
+  'node-8':
     docker:
       - image: circleci/node:8
     working_directory: ~/node-8
     steps: *buildSteps
 
-  deploy:
-    # For this to work NPM_TOKEN must be set for the account used for publishing
+  'node-10':
     docker:
-      - image: circleci/node:6
-    steps:
-      - attach_workspace:
-          at: $CIRCLE_WORKING_DIRECTORY
-      - run:
-          name: Build output
-          command: npm run build
-          working_directory: $CIRCLE_WORKING_DIRECTORY/node-6
-      - run:
-          name: Login to npm
-          command: |
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            npm whoami
-      - deploy:
-          name: Deploy to npm
-          command: npm publish
-          # Output used for publish is from node 6 build
-          working_directory: $CIRCLE_WORKING_DIRECTORY/node-6
+      - image: circleci/node:10
+    working_directory: ~/node-10
+    steps: *buildSteps
 
 workflows:
   version: 2
   build:
     jobs:
-      - "node-6":
-          # Run for all tags (required to allow the deploy to trigger on version tags)
-          filters:
-            tags:
-              only: /.*/
-      - "node-8":
-          # Run for all tags (required to allow the deploy to trigger on version tags)
-          filters:
-            tags:
-              only: /.*/
-      - deploy:
-          # Deploy passing builds if they're tagged with a version
-          requires:
-            - "node-6"
-            - "node-8"
-          filters:
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
+      - 'node-6'
+      - 'node-8'
+      - 'node-10'

--- a/lib/build.ts
+++ b/lib/build.ts
@@ -1,7 +1,6 @@
 import * as Promise from 'bluebird';
 import * as Dockerode from 'dockerode';
 import * as _ from 'lodash';
-import * as path from 'path';
 import { Builder, BuildHooks } from 'resin-docker-build';
 import * as Stream from 'stream';
 
@@ -106,7 +105,7 @@ export function runBuildTask(
 
 		if (task.dockerfilePath != null) {
 			dockerOpts = _.merge(dockerOpts, {
-				dockerfile: path.relative(task.context!, task.dockerfilePath),
+				dockerfile: task.dockerfilePath,
 			});
 		}
 

--- a/lib/build.ts
+++ b/lib/build.ts
@@ -109,7 +109,7 @@ export function runBuildTask(
 			});
 		}
 
-		const builder = new Builder(docker);
+		const builder = Builder.fromDockerode(docker);
 		const hooks = taskHooks(task, docker, resolve);
 
 		builder.createBuildStream(dockerOpts, hooks, reject);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1236,9 +1236,9 @@
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexify": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
-      "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "requires": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
@@ -3510,9 +3510,9 @@
       }
     },
     "resin-docker-build": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/resin-docker-build/-/resin-docker-build-0.7.1.tgz",
-      "integrity": "sha512-8W/oM5FvXzHu0ylOXfnAyR/TkjnmTz6X4AvYnBgFL6VHd+72tE9DzEv2nlBX7Au7v6jfk2fWpfC6GMr5hUhiDw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resin-docker-build/-/resin-docker-build-1.0.0.tgz",
+      "integrity": "sha512-reDrQnWyKf+8x/2x9H87TqCCc8IbsD3mWC/EfieoCVkwLSB81jBqHLYWsvPmLZRTkXytsxuEpeIuJ40s2ic3Xw==",
       "requires": {
         "@types/bluebird": "^3.0.37",
         "@types/dockerode": "2.5.5",
@@ -3534,9 +3534,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.2.tgz",
-          "integrity": "sha512-RO4ig5taKmcrU4Rex8ojG1gpwFkjddzug9iPQSDvbewHN9vDpcFewevkaOK+KT+w1LeZnxbgOyfXwV4pxsQ4GQ=="
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.5.tgz",
+          "integrity": "sha512-RYkagUUbxQBss46ElbEa+j4q4X3GR12QwB7a/PM5hmVuVkYoW1jENT1+taspKUv8ibwW8cw+kRFbOaTc/Key3w=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lodash": "^4.17.4",
     "resin-bundle-resolve": "^3.0.1",
     "resin-compose-parse": "^2.0.1",
-    "resin-docker-build": "^0.7.1",
+    "resin-docker-build": "^1.0.0",
     "tar-stream": "^1.6.2",
     "tar-utils": "^1.1.0",
     "typed-error": "^3.0.0"


### PR DESCRIPTION
Fixes:
* https://github.com/balena-io-modules/resin-multibuild/issues/43
* https://github.com/balena-io-modules/resin-multibuild/issues/34

Also fixes an issue where a Dockerode handle was not returning true in `handle instanceof Dockerode`.