### PR TITLE
Bump docker-progress major version (4.0.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1175,9 +1175,9 @@
       }
     },
     "docker-progress": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/docker-progress/-/docker-progress-3.0.4.tgz",
-      "integrity": "sha512-E0T0HDOKA3rKh9QSrJwASQvSv+PO1eP5F1mimfcwVBehXhRBHGT/JiXOR/0C9RRMrTFjpMvz4yj0l1CDB0z3Pw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/docker-progress/-/docker-progress-4.0.0.tgz",
+      "integrity": "sha512-AICTPgmeJ6C/u5irNWh9D8YeWDdoH0u19kZdNgpu+IL/vgu5eXjLhgNjHhwvnR+HuNVaZdEYomhR990reUR+tw==",
       "requires": {
         "@types/bluebird": "^3.5.18",
         "JSONStream": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/tar-stream": "1.6.0",
     "ajv": "^6.6.1",
     "bluebird": "^3.5.3",
-    "docker-progress": "^3.0.4",
+    "docker-progress": "^4.0.0",
     "docker-toolbelt": "^3.3.7",
     "dockerode": "^2.5.5",
     "lodash": "^4.17.4",


### PR DESCRIPTION
This change allows docker progress stream error events such as `'unauthorized: authentication required'` to be detected.

Change-type: patch
Signed-off-by: Paulo Castro <paulo@balena.io>
