### PR TITLE
Fix tar stream path handling under Windows and bump resin-bundle-resolve

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -28,6 +28,7 @@ import { BuildTask } from './build-task';
 import { BuildProcessError, TarError } from './errors';
 import { LocalImage } from './local-image';
 import * as PathUtils from './path-utils';
+import { posix, posixContains } from './path-utils';
 import { ResolveListeners, resolveTask } from './resolve';
 import * as Utils from './utils';
 
@@ -76,7 +77,7 @@ export function fromImageDescriptors(
 				if (task.external) {
 					return false;
 				}
-				return PathUtils.contains(task.context!, header.name);
+				return posixContains(task.context!, header.name);
 			});
 
 			if (matchingTasks.length > 0) {
@@ -85,7 +86,7 @@ export function fromImageDescriptors(
 					.then(buf => {
 						matchingTasks.forEach(task => {
 							const newHeader = _.cloneDeep(header);
-							newHeader.name = PathUtils.relative(task.context!, header.name);
+							newHeader.name = posix.relative(task.context!, header.name);
 							task.buildStream!.entry(newHeader, buf);
 						});
 					})

--- a/lib/path-utils.ts
+++ b/lib/path-utils.ts
@@ -14,24 +14,61 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { normalize, relative } from 'path';
+import * as _ from 'lodash';
+import * as path from 'path';
+import { posix } from 'path';
 
 // Export all of node's path functions, so that users of this
 // module need only import this file
 export * from 'path';
 
+const nativeSepRE = new RegExp(_.escapeRegExp(path.sep), 'g');
+const nativeDotDotRE = new RegExp('^\\.\\.$|\\.\\.' + _.escapeRegExp(path.sep));
+
 /**
- * Given two paths, check whether the first contains the second
- * @param path1 The potentially containing path
- * @param path2 The potentially contained path
+ * Given two native (platform-dependent) paths, check whether the first
+ * contains the second
+ * @param path1 The potentially containing native path
+ * @param path2 The potentially contained native path
  * @return A boolean indicating whether `path1` contains `path2`
  */
 export const contains = (path1: string, path2: string): boolean => {
 	// First normalise the input, to remove any path weirdness
-	path1 = normalize(path1);
-	path2 = normalize(path2);
+	path1 = path.normalize(path1);
+	path2 = path.normalize(path2);
 
 	// Now test if any part of the relative path contains a .. ,
 	// which would tell us that path1 is not part of path2
-	return !/^\.\.$|\.\.\//.test(relative(path1, path2));
+	return !nativeDotDotRE.test(path.relative(path1, path2));
 };
+
+/**
+ * Given two POSIX paths, check whether the first contains the second
+ * @param path1 The potentially containing POSIX path
+ * @param path2 The potentially contained POSIX path
+ * @return A boolean indicating whether `path1` contains `path2`
+ */
+export const posixContains = (path1: string, path2: string): boolean => {
+	// First normalise the input, to remove any path weirdness
+	path1 = posix.normalize(path1);
+	path2 = posix.normalize(path2);
+
+	// Now test if any part of the relative path contains a .. ,
+	// which would tell us that path1 is not part of path2
+	return !/^\.\.$|\.\.\//.test(posix.relative(path1, path2));
+};
+
+/**
+ * Replace "native path separators" like '\' with the POSIX '/' separator.
+ * This function is handy but bear in mind that conversion from Windows paths
+ * to POSIX is not that simple when a drive letter is specified for either
+ * absolute or per-drive relative paths, e.g. 'C:\absolute' or 'C:relative',
+ * or when the path refers to a network server, e.g. '\\server\folder\file'.
+ */
+export function toPosixPath(p: string): string {
+	return p.replace(nativeSepRE, '/');
+}
+
+export function toNativePath(p: string): string {
+	return p.replace(/\//g, path.sep);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1773,7 +1773,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -2742,7 +2742,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -4081,9 +4081,9 @@
       "dev": true
     },
     "resin-bundle-resolve": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resin-bundle-resolve/-/resin-bundle-resolve-4.0.0.tgz",
-      "integrity": "sha512-yjvuvfUF/0gq3WVzwJjzCsjoNG8HzvyTOmz2jsiAw4MBrZjgJObY/W79A8Y0cPiPtJMgSx18FkkKjxFORUrgUw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/resin-bundle-resolve/-/resin-bundle-resolve-4.1.0.tgz",
+      "integrity": "sha512-TcQ46g4tRGsA0wn+5Ejh7LlvSsLc29vkcbD4l4bKaBj7xwOQENlJQASHine71dDFdYQStwzwLsfOPi+0jG9F2w==",
       "requires": {
         "@types/tar-stream": "^1.6.0",
         "bluebird": "^3.5.4",
@@ -4868,22 +4868,15 @@
       }
     },
     "tar-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tar-utils/-/tar-utils-1.1.0.tgz",
-      "integrity": "sha512-g3ycDEyBX7HqnvgTg2WBidpwvJDXqCMb2umrzm3PMkdz2oMLggFEHR7ryxIQgNMB1GwqLi2DUHwrJClWNx5hMw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tar-utils/-/tar-utils-2.0.0.tgz",
+      "integrity": "sha512-ru7cnOD2K+AqBoY98obDu8E1go+m0DXb1OBIyYewk/C9h2Sz/LShwKfqSvUC3Z8c9Zll/dxzNaaY2lkFH7Wvkg==",
       "requires": {
-        "@types/bluebird": "^3.5.3",
-        "@types/node": "^10.12.26",
-        "@types/tar-stream": "1.6.0",
         "bluebird": "^3.5.0",
+        "lodash": "^4.17.11",
         "tar-stream": "^1.6.2"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "10.12.26",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.26.tgz",
-          "integrity": "sha512-nMRqS+mL1TOnIJrL6LKJcNZPB8V3eTfRo9FQA2b5gDvrHurC8XbSA86KNe0dShlEL7ReWJv/OU9NL7Z0dnqWTg=="
-        },
         "bl": {
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -5361,7 +5354,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -48,11 +48,11 @@
     "docker-toolbelt": "^3.3.7",
     "dockerode": "^2.5.8",
     "lodash": "^4.17.4",
-    "resin-bundle-resolve": "^4.0.0",
+    "resin-bundle-resolve": "^4.1.0",
     "resin-compose-parse": "^2.0.4",
     "resin-docker-build": "^1.0.1",
     "tar-stream": "^2.0.1",
-    "tar-utils": "^1.1.0",
+    "tar-utils": "^2.0.0",
     "typed-error": "^3.1.0"
   },
   "husky": {

--- a/test/path-utils.spec.ts
+++ b/test/path-utils.spec.ts
@@ -1,4 +1,20 @@
-import * as Promise from 'bluebird';
+/**
+ * @license
+ * Copyright 2018 Balena Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 
@@ -9,38 +25,81 @@ const expect = chai.expect;
 
 describe('Path utilities', () => {
 	it('should correctly create relative paths', done => {
-		expect(PathUtils.relative('.', 'testDirectory')).to.equal('testDirectory');
-
-		expect(PathUtils.relative('test1', 'test1/test2')).to.equal('test2');
-
-		expect(PathUtils.relative('./test1', 'test1/test2')).to.equal('test2');
-
-		expect(PathUtils.relative('.', 'file')).to.equal('file');
-
-		expect(PathUtils.relative('.', './file')).to.equal('file');
-
-		expect(PathUtils.relative('test1/test2/', 'test1/test2/test3')).to.equal(
-			'test3',
-		);
-
+		const testCases = [
+			// [from, to, expected]
+			['.', 'testDirectory', 'testDirectory'],
+			['test1', 'test1/test2', 'test2'],
+			['./test1', 'test1/test2', 'test2'],
+			['.', 'file', 'file'],
+			['.', './file', 'file'],
+			['test1/test2/', 'test1/test2/test3', 'test3'],
+		];
+		for (let [from, to, expected] of testCases) {
+			expect(PathUtils.posix.relative(from, to)).to.equal(
+				expected,
+				`expected posix.relative("${from}", "${to}") to equal "${expected}"`,
+			);
+			from = PathUtils.toNativePath(from);
+			to = PathUtils.toNativePath(to);
+			expected = PathUtils.toNativePath(expected);
+			expect(PathUtils.relative(from, to)).to.equal(
+				expected,
+				`expected native relative("${from}", "${to}") to equal "${expected}"`,
+			);
+		}
 		done();
 	});
 
 	it('should correctly detect contained paths', done => {
-		expect(PathUtils.contains('.', 'test')).to.equal(true);
-		expect(PathUtils.contains('.', './test')).to.equal(true);
-		expect(PathUtils.contains('./test', 'test/file')).to.equal(true);
-		expect(PathUtils.contains('./test1/test2', 'test1/file')).to.equal(false);
-		expect(PathUtils.contains('./test1', 'file')).to.equal(false);
-		expect(PathUtils.contains('test1/test2/test3', 'test1')).to.equal(false);
+		const testCases: Array<[string, string, boolean]> = [
+			// [path1, path2, expected]
+			['.', 'test', true],
+			['.', './test', true],
+			['./test', 'test/file', true],
+			['./test1/test2', 'test1/file', false],
+			['./test1', 'file', false],
+			['test1/test2/test3', 'test1', false],
+			['./test1/test2/test3', 'test1/test2/test3/file', true],
+			['.', '..', false],
+			['test1', 'test2/../test1/file', true],
+		];
+		for (let [path1, path2, expected] of testCases) {
+			expect(PathUtils.posixContains(path1, path2)).to.equal(
+				expected,
+				`expected posixContains("${path1}", "${path2}") to equal "${expected}"`,
+			);
+			path1 = PathUtils.toNativePath(path1);
+			path2 = PathUtils.toNativePath(path2);
+			expect(PathUtils.contains(path1, path2)).to.equal(
+				expected,
+				`expected PathUtils.contains("${path1}", "${path2}") to equal "${expected}"`,
+			);
+		}
+		done();
+	});
 
-		expect(
-			PathUtils.contains('./test1/test2/test3', 'test1/test2/test3/file'),
-		).to.equal(true);
-
-		expect(PathUtils.contains('.', '..')).to.equal(false);
-		expect(PathUtils.contains('test1', 'test2/../test1/file')).to.equal(true);
-
+	it('should convert from posix to native and back without loss', done => {
+		const testCases = [
+			['..'],
+			['.'],
+			['./test'],
+			['./test1'],
+			['./test1/test2'],
+			['./test1/test2/test3'],
+			['file'],
+			['test'],
+			['test/file'],
+			['test1'],
+			['test1/file'],
+			['test1/test2/test3'],
+			['test2/../test1/file'],
+		];
+		for (const [path] of testCases) {
+			expect(path).to.equal(PathUtils.toPosixPath(path));
+			expect(path).to.equal(
+				PathUtils.toPosixPath(PathUtils.toNativePath(path)),
+			);
+		}
 		done();
 	});
 });


### PR DESCRIPTION
See issue #51 for the main objective of this PR.

User-visible (ish) changes:
* The bump of resin-bundle-resolve provides part of the requirements to allow the use of alternative template or arch-specific Dockerfile names, such as `MyDockerfile.template` or `MyDockerfile.armv7hf`.
* Provides part of the fix for incorrect path handling of tar streams on Windows (forward-slash vs backslash path separators) which causes `balena push ipAddress` and `balena deploy` to fail on Windows.

Resolves: #51
Connects-to: https://github.com/balena-io/balena-cli/issues/1133
Depends-on: https://github.com/balena-io-modules/resin-bundle-resolve/pull/36
Change-type: minor
Signed-off-by: Paulo Castro <paulo@balena.io>