### PR TITLE
Add single task resolution function to enable better error reporting

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -180,6 +180,16 @@ export function performResolution(
 	});
 }
 
+export function performSingleResolution(
+	task: BuildTask,
+	architecture: string,
+	deviceType: string,
+	resolveListeners: ResolveListeners,
+): BuildTask {
+	task.architecture = architecture;
+	return resolveTask(task, architecture, deviceType, resolveListeners);
+}
+
 /**
  * Given a list of build tasks, and a handle to a docker daemon, this function
  * will perform the tasks and return a list of LocalImage values, which


### PR DESCRIPTION
This allows the error callbacks to be specific per-service and it at least will provide the service and most likely the reason for resolution failure.

Depends-on: https://github.com/balena-io-modules/resin-bundle-resolve/pull/38
Change-type: minor
Signed-off-by: Cameron Diver <cameron@balena.io>