### PR TITLE
Fix path operations and get 'npm test' to pass on Windows

### DIFF
--- a/lib/build-metadata.ts
+++ b/lib/build-metadata.ts
@@ -81,7 +81,7 @@ export class BuildMetadata {
 	}
 
 	public getSecretFile(source: string): Buffer | undefined {
-		return this.metadataFiles[PathUtils.join('secrets', source)];
+		return this.metadataFiles[PathUtils.posix.join('secrets', source)];
 	}
 
 	public parseMetadata() {
@@ -202,9 +202,9 @@ export class BuildMetadata {
 		path: string,
 	): { relativePath: string; metadataDirectory: string } | undefined {
 		for (const metadataDirectory of this.metadataDirectories) {
-			if (PathUtils.contains(metadataDirectory, path)) {
+			if (PathUtils.posixContains(metadataDirectory, path)) {
 				return {
-					relativePath: PathUtils.relative(metadataDirectory, path),
+					relativePath: PathUtils.posix.relative(metadataDirectory, path),
 					metadataDirectory,
 				};
 			}

--- a/lib/build-secrets/index.ts
+++ b/lib/build-secrets/index.ts
@@ -75,7 +75,10 @@ export function generateSecretPopulationMap(
 
 	for (const serviceName of serviceNames) {
 		const serviceSecret: SecretsPopulationMap[''] = {
-			tmpDirectory: path.join(tmpDir, crypto.randomBytes(10).toString('hex')),
+			tmpDirectory: path.posix.join(
+				tmpDir,
+				crypto.randomBytes(10).toString('hex'),
+			),
 			files: {},
 		};
 
@@ -127,7 +130,7 @@ export async function populateSecrets(
 		JSON.stringify(secrets),
 	);
 	const dockerfileContent = dockerfileTemplate.process(
-		await fs.readFile(path.join(__dirname, './Dockerfile'), 'utf8'),
+		await fs.readFile(path.join(__dirname, 'Dockerfile'), 'utf8'),
 		{
 			ARCH: architecture,
 		},
@@ -187,7 +190,7 @@ export async function removeSecrets(
 		JSON.stringify(_.map(secrets, ({ tmpDirectory }) => tmpDirectory)),
 	);
 	const dockerfileContent = dockerfileTemplate.process(
-		await fs.readFile(path.join(__dirname, './Dockerfile.remove'), 'utf8'),
+		await fs.readFile(path.join(__dirname, 'Dockerfile.remove'), 'utf8'),
 		{
 			ARCH: architecture,
 		},

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
   ],
   "types": "build/index.d.ts",
   "scripts": {
-    "clean": "rm -rf build",
+    "clean": "rimraf -rf build",
     "prepublishOnly": "npm run build && npm run lint",
     "prettify": "prettier --config ./node_modules/resin-lint/config/.prettierrc --write \"{lib,test,typings}/**/*.ts\"",
     "lint": "resin-lint --typescript lib typings test",
     "build": "npm run clean && tsc --project tsconfig.publish.json && npm run copy-secrets",
     "build:test": "npm run clean && tsc --project . && npm run copy-secrets:test",
-    "copy-secrets": "cp lib/build-secrets/Dockerfile* build/build-secrets",
-    "copy-secrets:test": "cp lib/build-secrets/Dockerfile* build/lib/build-secrets",
+    "copy-secrets": "ncp lib/build-secrets build/build-secrets --filter=\"build-secrets($|.Dockerfile.*)\"",
+    "copy-secrets:test": "ncp lib/build-secrets build/lib/build-secrets --filter=\"build-secrets($|.Dockerfile.*)\"",
     "docgen": "typedoc --ignoreCompilerErrors --out docs --name resin-multibuild --readme README.md lib/",
     "test": "npm run lint && npm run build:test && mocha"
   },
@@ -38,8 +38,10 @@
     "husky": "^1.3.1",
     "lint-staged": "^8.1.5",
     "mocha": "^6.1.3",
+    "ncp": "^2.0.0",
     "prettier": "^1.16.4",
     "resin-lint": "^3.0.2",
+    "rimraf": "^3.0.0",
     "typedoc": "^0.9.0",
     "typescript": "^3.4.3"
   },

--- a/test/build-utils.ts
+++ b/test/build-utils.ts
@@ -60,7 +60,10 @@ function getDockerOpts(extraOpts?: any): Dockerode.DockerOptions {
 		};
 	} else {
 		dockerOpts = {
-			socketPath: '/var/run/docker.sock',
+			socketPath:
+				process.platform === 'win32'
+					? '//./pipe/docker_engine'
+					: '/var/run/docker.sock',
 			Promise: Bluebird as any,
 		};
 	}

--- a/test/build.spec.ts
+++ b/test/build.spec.ts
@@ -39,7 +39,7 @@ const expect = chai.expect;
 
 const docker = getDocker();
 
-const buildMetadata = new TestBuildMetadata(['.balena/', '.resin/'], {
+const buildMetadata = new TestBuildMetadata(['.balena', '.resin'], {
 	buildSecrets: {},
 	buildVariables: {},
 });

--- a/test/multibuild.spec.ts
+++ b/test/multibuild.spec.ts
@@ -44,7 +44,7 @@ describe('performBuilds()', () => {
 	it.skip('correctly builds a task using build secrets', async () => {
 		const outParser = new StreamOutputParser();
 		const tarFilename = 'test/test-files/build-secrets-1.tar';
-		const buildMetadata = new BuildMetadata(['.balena/', '.resin/']);
+		const buildMetadata = new BuildMetadata(['.balena', '.resin']);
 		await buildMetadata.extractMetadata(fs.createReadStream(tarFilename));
 
 		const task: BuildTask = {


### PR DESCRIPTION
Addresses issue #64 ["balena build" on Windows: "\\\\var\\\\lib\\\\docker\\\\tmp\\\\ed1f9f5a84d092cf7c3e" includes invalid characters for a local volume name](https://github.com/balena-io-modules/resin-multibuild/issues/64)

Change-type: patch
Signed-off-by: Paulo Castro <paulo@balena.io>