### PR TITLE
Expose base images info on LocalImage

### DIFF
--- a/lib/local-image.ts
+++ b/lib/local-image.ts
@@ -49,6 +49,11 @@ export class LocalImage {
 	public layers?: string[];
 
 	/**
+	 * Base image tags referred by this image build
+	 */
+	public baseImageTags?: Array<{ repo: string; tag: string }>;
+
+	/**
 	 * Was this image built successfully?
 	 *
 	 * Note that in the case of an image not being successfully built,

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lodash": "^4.17.4",
     "resin-bundle-resolve": "^4.1.3",
     "resin-compose-parse": "^2.0.4",
-    "resin-docker-build": "^1.0.1",
+    "resin-docker-build": "^1.1.2",
     "tar-stream": "^2.0.1",
     "tar-utils": "^2.0.0",
     "typed-error": "^3.1.0"


### PR DESCRIPTION
LocalImage now has a property that lists images used in FROM
instructions in Dockerfile.

Depends on https://github.com/balena-io/resin-docker-build/pull/37

Change-type: patch
Signed-off-by: Roman Mazur <mazur.roman@gmail.com>