### PR TITLE
Add platform option in runBuildTask

### DIFF
--- a/lib/build.ts
+++ b/lib/build.ts
@@ -2,6 +2,7 @@ import * as Promise from 'bluebird';
 import * as Dockerode from 'dockerode';
 import * as _ from 'lodash';
 import { Builder, BuildHooks, FromTagInfo } from 'resin-docker-build';
+import * as semver from 'semver';
 import * as Stream from 'stream';
 
 import { SecretsPopulationMap } from './build-secrets';
@@ -90,20 +91,36 @@ const generateLabels = (task: BuildTask): { labels?: Dictionary<string> } => {
  * @param docker The handle to the docker daemon
  * @return a promise which resolves to a LocalImage which points to the produced image
  */
-export function runBuildTask(
+export async function runBuildTask(
 	task: BuildTask,
 	docker: Dockerode,
 	registrySecrets: RegistrySecrets,
 	secrets?: SecretsPopulationMap,
 	buildArgs?: Dictionary<string>,
 ): Promise<LocalImage> {
-	// First merge in the registry secrets (optionally being
-	// overridden by user input) so that they're available for
-	// both pull and build
-	task.dockerOpts = _.merge(
-		{ registryconfig: registrySecrets },
-		task.dockerOpts,
-	);
+	// check if docker supports propagating which platform to build for
+	// NOTE: docker api version 1.34 actually introduced platform to the
+	// api but it was broken until fixed in
+	// https://github.com/moby/moby/commit/7f334d3acfd7bfde900e16e393662587b9ff74a1
+	// which is why we check for 1.38 here
+	const usePlatformOption: boolean =
+		!!task.dockerPlatform &&
+		semver.satisfies(
+			semver.coerce((await docker.version()).ApiVersion) || '0.0.0',
+			'>=1.38.0',
+		);
+
+	task.dockerOpts = {
+		// First merge in the registry secrets (optionally being
+		// overridden by user input) so that they're available for
+		// both pull and build
+		registryconfig: registrySecrets,
+		// then merge in the target platform to ensure pullExternal
+		// also considers it
+		...(usePlatformOption ? { platform: task.dockerPlatform } : {}),
+		...task.dockerOpts,
+	};
+
 	if (task.external) {
 		// Handle this separately
 		return pullExternal(task, docker);

--- a/lib/build.ts
+++ b/lib/build.ts
@@ -1,4 +1,3 @@
-import * as Promise from 'bluebird';
 import * as Dockerode from 'dockerode';
 import * as _ from 'lodash';
 import { Builder, BuildHooks, FromTagInfo } from 'resin-docker-build';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -20,7 +20,6 @@ import * as Dockerode from 'dockerode';
 import * as _ from 'lodash';
 import * as path from 'path';
 import * as Compose from 'resin-compose-parse';
-import * as semver from 'semver';
 import * as Stream from 'stream';
 import * as tar from 'tar-stream';
 import * as TarUtils from 'tar-utils';
@@ -265,17 +264,9 @@ export async function performBuilds(
 		secrets: secretMap,
 		regSecrets: registrySecrets,
 		architecture,
-		apiVersion,
 	} = await initializeBuildMetadata(tasks, docker, tmpDir);
 
 	const images = await Bluebird.map(tasks, (task: BuildTask) => {
-		if (
-			task.dockerPlatform &&
-			apiVersion &&
-			semver.satisfies(apiVersion, '>=1.38.0')
-		) {
-			task.dockerOpts = { platform: task.dockerPlatform, ...task.dockerOpts };
-		}
 		return performSingleBuild(
 			task,
 			docker,
@@ -303,22 +294,18 @@ export async function initializeBuildMetadata(
 	secrets: SecretsPopulationMap;
 	regSecrets: RegistrySecrets;
 	architecture: string;
-	apiVersion: semver.SemVer | null;
 }> {
 	if (tasks.length === 0) {
 		return {
 			secrets: {},
 			regSecrets: {},
 			architecture: '',
-			apiVersion: null,
 		};
 	}
 	// This feels a bit dirty, but there doesn't seem another
 	// nicer way to do it given the current setup
 	const buildMetadata = tasks[0].buildMetadata;
-	const versionOutput = await docker.version();
-	const architecture = versionOutput.Arch;
-	const apiVersion = semver.coerce(versionOutput.ApiVersion);
+	const architecture = (await docker.version()).Arch;
 
 	buildMetadata.parseMetadata();
 	const registrySecrets = buildMetadata.registrySecrets;
@@ -338,7 +325,6 @@ export async function initializeBuildMetadata(
 		secrets: secretMap,
 		regSecrets: registrySecrets,
 		architecture,
-		apiVersion,
 	};
 }
 

--- a/test/build.spec.ts
+++ b/test/build.spec.ts
@@ -292,13 +292,13 @@ describe('Invalid build input', () => {
 			.then(() => {
 				throw new Error('Error not thrown on null buildStream input');
 			})
-			.catch(BuildProcessError, () => {
-				// This is what we want
-			})
 			.catch(e => {
-				throw new Error(
-					'Incorrect error thrown on null buildStream input: ' + e,
-				);
+				// This is what we want
+				if (!(e instanceof BuildProcessError)) {
+					throw new Error(
+						'Incorrect error thrown on null buildStream input: ' + e,
+					);
+				}
 			});
 	});
 });

--- a/test/build.spec.ts
+++ b/test/build.spec.ts
@@ -258,6 +258,7 @@ describe('Resolved project building', () => {
 			serviceName: 'test',
 			streamHook: streamPrinter,
 			buildMetadata,
+			dockerOpts: { pull: true },
 		};
 		return new Promise((resolve, reject) => {
 			const resolveListeners = {

--- a/test/resolve.spec.ts
+++ b/test/resolve.spec.ts
@@ -1,4 +1,3 @@
-import * as Promise from 'bluebird';
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as fs from 'fs';


### PR DESCRIPTION
the previous PR #80 only added platform support to `performBuilds`

commit `Add platform in runBuildTask` (https://github.com/balena-io-modules/resin-multibuild/commit/d1f813b552f1587483cdbae12bab7a5c8e3a87dd) moves to the shared function ~~(which is also exported, so needs to be covered anyway)~~

~~I had to add another call to `docker.version()` in order to get the api version there... so I attempted to improve that by breaking API (as we discussed before)~~

~~https://github.com/balena-io-modules/resin-multibuild/commit/4cc18980506a175970788a960b578984dc044604 makes it the responsibility of the caller to fill `builderVersion` on a build task, which we then use here~~

Let me know what you think...