### PR TITLE
Avoid overwriting docker build options with undefined values

### DIFF
--- a/lib/build.ts
+++ b/lib/build.ts
@@ -109,16 +109,16 @@ export async function runBuildTask(
 			'>=1.38.0',
 		);
 
-	task.dockerOpts = {
+	task.dockerOpts = _.merge(
 		// First merge in the registry secrets (optionally being
 		// overridden by user input) so that they're available for
 		// both pull and build
-		registryconfig: registrySecrets,
+		{ registryconfig: registrySecrets },
 		// then merge in the target platform to ensure pullExternal
 		// also considers it
-		...(usePlatformOption ? { platform: task.dockerPlatform } : {}),
-		...task.dockerOpts,
-	};
+		usePlatformOption ? { platform: task.dockerPlatform } : {},
+		task.dockerOpts,
+	);
 
 	if (task.external) {
 		// Handle this separately

--- a/test/build.spec.ts
+++ b/test/build.spec.ts
@@ -265,6 +265,11 @@ describe('Resolved project building', () => {
 				error: [reject],
 			};
 			const newTask = resolveTask(task, 'i386', 'qemux86', resolveListeners);
+
+			// also test that a `platform: undefined` value in `task.dockerOpts`
+			// does not override a valid value in `task.dockerPlatform`
+			task.dockerOpts.platform = undefined;
+
 			resolve(runBuildTask(newTask, docker, secretMap, buildVars));
 		})
 			.then((image: LocalImage) => {


### PR DESCRIPTION
This PR fixes a "potential" bug. I have not actually come across a problem in practice, but while integrating the latest version of multibuild in the balena CLI, I noticed that the `platform` and `registryconfig` docker build options could be overwritten with `undefined` (as explained in a comment) which is not ideal and didn't happen before PR #85.

Change-type: patch